### PR TITLE
Fixed missing variable & updated required locales

### DIFF
--- a/lib/vagrant-service-manager/services/open_shift.rb
+++ b/lib/vagrant-service-manager/services/open_shift.rb
@@ -19,6 +19,7 @@ module VagrantPlugins
       end
 
       def self.docker_registry_url(machine)
+        url = ''
         PluginLogger.debug
         command = "sudo oc --config=/var/lib/openshift/openshift.local." +
                   "config/master/admin.kubeconfig get " +

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -120,19 +120,23 @@ en:
             # To use OpenShift CLI, run: oc login %{openshift_url}
             setx OPENSHIFT_URL %{openshift_url}
             setx OPENSHIFT_WEB_CONSOLE %{openshift_console_url}
+            setx DOCKER_REGISTRY %{docker_registry}
           non_windows: |-
             # You can access the OpenShift console on: %{openshift_console_url}
             # To use OpenShift CLI, run: oc login %{openshift_url}
             export OPENSHIFT_URL=%{openshift_url}
             export OPENSHIFT_WEB_CONSOLE=%{openshift_console_url}
+            export DOCKER_REGISTRY=%{docker_registry}
           windows_cygwin: |-
             # You can access the OpenShift console on: %{openshift_console_url}
             # To use OpenShift CLI, run: oc login %{openshift_url}
             export OPENSHIFT_URL=%{openshift_url}
             export OPENSHIFT_WEB_CONSOLE=%{openshift_console_url}
+            export DOCKER_REGISTRY=%{docker_registry}
           script_readable: |-
             OPENSHIFT_URL=%{openshift_url}
             OPENSHIFT_WEB_CONSOLE=%{openshift_console_url}
+            DOCKER_REGISTRY=%{docker_registry}
         windows_cygwin_configure_info: |-
             # run following command to configure your shell:
             # eval "$(VAGRANT_NO_COLOR=1 vagrant service-manager env%{command} | tr -d '\r')"


### PR DESCRIPTION
My logs follows:

```
➜  vagrant-service-manager git:(fix-210) ✗ be vagrant service-manager env openshift                  
# You can access the OpenShift console on: https://10.1.2.2:8443/console
# To use OpenShift CLI, run: oc login https://10.1.2.2:8443
export OPENSHIFT_URL=https://10.1.2.2:8443
export OPENSHIFT_WEB_CONSOLE=https://10.1.2.2:8443/console
export DOCKER_REGISTRY=hub.openshift.rhel-cdk.10.1.2.2.xip.io

# run following command to configure your shell:
# eval "$(vagrant service-manager env openshift)"
```

Hope this is the expected one.
